### PR TITLE
Fixed pagination layout when there is no page links

### DIFF
--- a/src/Pagination/Layouts/default-pagination.php
+++ b/src/Pagination/Layouts/default-pagination.php
@@ -22,5 +22,7 @@
         </li>
     <?php } ?>
     </ul>
-    <p class="pull-left remaining">mostrando <?php echo $currentNumRecords; ?> de <?php echo $totalRecords; ?> registros</p>
+    <?php if (count($numbers) > 0) { ?>
+        <p class="pull-left remaining">mostrando <?php echo $currentNumRecords; ?> de <?php echo $totalRecords; ?> registros</p>
+    <?php } ?>
 </div>


### PR DESCRIPTION
When there weren't page link numbers, it was showing an unnecessary and wrong message, it was fixed to not display that message